### PR TITLE
Nuget source url should not be fully qualified

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -490,7 +490,7 @@ jobs:
           version: ${{ needs.calc-version.outputs.version }}
           tag-commit: false
           nuget-key: ${{secrets.NUGET_API_KEY}}
-          nuget-source: https://nuget.pkg.github.com/BESTSELLER/index.json
+          nuget-source: https://nuget.pkg.github.com/BESTSELLER
       - name: Build and Publish MassTransit Abstractions
         # was: brandedoutcast/publish-nuget@v2.5.5
         uses: drusellers/publish-nuget@master
@@ -499,7 +499,7 @@ jobs:
           version: ${{ needs.calc-version.outputs.version }}
           tag-commit: false
           nuget-key: ${{secrets.NUGET_API_KEY}}
-          nuget-source: https://nuget.pkg.github.com/BESTSELLER/index.json
+          nuget-source: https://nuget.pkg.github.com/BESTSELLER
       - name: Build and Publish MassTransit Newtonsoft
         # was: brandedoutcast/publish-nuget@v2.5.5
         uses: drusellers/publish-nuget@master
@@ -508,7 +508,7 @@ jobs:
           version: ${{ needs.calc-version.outputs.version }}
           tag-commit: false
           nuget-key: ${{secrets.NUGET_API_KEY}}
-          nuget-source: https://nuget.pkg.github.com/BESTSELLER/index.json
+          nuget-source: https://nuget.pkg.github.com/BESTSELLER
       - name: Build and Publish MassTransit.Analyzers
         uses: drusellers/publish-nuget@master
         with:
@@ -516,7 +516,7 @@ jobs:
           version: ${{ needs.calc-version.outputs.version }}
           tag-commit: false
           nuget-key: ${{secrets.NUGET_API_KEY}}
-          nuget-source: https://nuget.pkg.github.com/BESTSELLER/index.json
+          nuget-source: https://nuget.pkg.github.com/BESTSELLER
           include-symbols: false
       - name: Build and Publish MassTransit.Interop.NServiceBus
         uses: drusellers/publish-nuget@master
@@ -525,7 +525,7 @@ jobs:
           version: ${{ needs.calc-version.outputs.version }}
           tag-commit: false
           nuget-key: ${{secrets.NUGET_API_KEY}}
-          nuget-source: https://nuget.pkg.github.com/BESTSELLER/index.json
+          nuget-source: https://nuget.pkg.github.com/BESTSELLER
       - name: Build and Publish MassTransit.PrometheusIntegration
         uses: drusellers/publish-nuget@master
         with:
@@ -533,7 +533,7 @@ jobs:
           version: ${{ needs.calc-version.outputs.version }}
           tag-commit: false
           nuget-key: ${{secrets.NUGET_API_KEY}}
-          nuget-source: https://nuget.pkg.github.com/BESTSELLER/index.json
+          nuget-source: https://nuget.pkg.github.com/BESTSELLER
       - name: Build and Publish MassTransit.SignalR
         uses: drusellers/publish-nuget@master
         with:
@@ -541,7 +541,7 @@ jobs:
           version: ${{ needs.calc-version.outputs.version }}
           tag-commit: false
           nuget-key: ${{secrets.NUGET_API_KEY}}
-          nuget-source: https://nuget.pkg.github.com/BESTSELLER/index.json
+          nuget-source: https://nuget.pkg.github.com/BESTSELLER
       - name: Build and Publish MassTransit.TestFramework
         uses: drusellers/publish-nuget@master
         with:
@@ -549,7 +549,7 @@ jobs:
           version: ${{ needs.calc-version.outputs.version }}
           tag-commit: false
           nuget-key: ${{secrets.NUGET_API_KEY}}
-          nuget-source: https://nuget.pkg.github.com/BESTSELLER/index.json
+          nuget-source: https://nuget.pkg.github.com/BESTSELLER
       - name: Build and Publish MassTransit.Azure.Cosmos
         uses: drusellers/publish-nuget@master
         with:
@@ -557,7 +557,7 @@ jobs:
           version: ${{ needs.calc-version.outputs.version }}
           tag-commit: false
           nuget-key: ${{secrets.NUGET_API_KEY}}
-          nuget-source: https://nuget.pkg.github.com/BESTSELLER/index.json
+          nuget-source: https://nuget.pkg.github.com/BESTSELLER
       - name: Build and Publish MassTransit.Azure.Storage
         uses: drusellers/publish-nuget@master
         with:
@@ -565,7 +565,7 @@ jobs:
           version: ${{ needs.calc-version.outputs.version }}
           tag-commit: false
           nuget-key: ${{secrets.NUGET_API_KEY}}
-          nuget-source: https://nuget.pkg.github.com/BESTSELLER/index.json
+          nuget-source: https://nuget.pkg.github.com/BESTSELLER
       - name: Build and Publish MassTransit.Azure.Table
         uses: drusellers/publish-nuget@master
         with:
@@ -573,7 +573,7 @@ jobs:
           version: ${{ needs.calc-version.outputs.version }}
           tag-commit: false
           nuget-key: ${{secrets.NUGET_API_KEY}}
-          nuget-source: https://nuget.pkg.github.com/BESTSELLER/index.json
+          nuget-source: https://nuget.pkg.github.com/BESTSELLER
       - name: Build and Publish MassTransit.DapperIntegration
         uses: drusellers/publish-nuget@master
         with:
@@ -581,7 +581,7 @@ jobs:
           version: ${{ needs.calc-version.outputs.version }}
           tag-commit: false
           nuget-key: ${{secrets.NUGET_API_KEY}}
-          nuget-source: https://nuget.pkg.github.com/BESTSELLER/index.json
+          nuget-source: https://nuget.pkg.github.com/BESTSELLER
       - name: Build and Publish MassTransit.DynamoDb
         uses: drusellers/publish-nuget@master
         with:
@@ -589,7 +589,7 @@ jobs:
           version: ${{ needs.calc-version.outputs.version }}
           tag-commit: false
           nuget-key: ${{secrets.NUGET_API_KEY}}
-          nuget-source: https://nuget.pkg.github.com/BESTSELLER/index.json
+          nuget-source: https://nuget.pkg.github.com/BESTSELLER
       - name: Build and Publish MassTransit.EntityFrameworkCoreIntegration
         uses: drusellers/publish-nuget@master
         with:
@@ -597,7 +597,7 @@ jobs:
           version: ${{ needs.calc-version.outputs.version }}
           tag-commit: false
           nuget-key: ${{secrets.NUGET_API_KEY}}
-          nuget-source: https://nuget.pkg.github.com/BESTSELLER/index.json
+          nuget-source: https://nuget.pkg.github.com/BESTSELLER
       - name: Build and Publish MassTransit.EntityFrameworkIntegration
         uses: drusellers/publish-nuget@master
         with:
@@ -605,7 +605,7 @@ jobs:
           version: ${{ needs.calc-version.outputs.version }}
           tag-commit: false
           nuget-key: ${{secrets.NUGET_API_KEY}}
-          nuget-source: https://nuget.pkg.github.com/BESTSELLER/index.json
+          nuget-source: https://nuget.pkg.github.com/BESTSELLER
       - name: Build and Publish MassTransit.MartenIntegration
         uses: drusellers/publish-nuget@master
         with:
@@ -613,7 +613,7 @@ jobs:
           version: ${{ needs.calc-version.outputs.version }}
           tag-commit: false
           nuget-key: ${{secrets.NUGET_API_KEY}}
-          nuget-source: https://nuget.pkg.github.com/BESTSELLER/index.json
+          nuget-source: https://nuget.pkg.github.com/BESTSELLER
       - name: Build and Publish MassTransit.MongoDbIntegration
         uses: drusellers/publish-nuget@master
         with:
@@ -621,7 +621,7 @@ jobs:
           version: ${{ needs.calc-version.outputs.version }}
           tag-commit: false
           nuget-key: ${{secrets.NUGET_API_KEY}}
-          nuget-source: https://nuget.pkg.github.com/BESTSELLER/index.json
+          nuget-source: https://nuget.pkg.github.com/BESTSELLER
       - name: Build and Publish MassTransit.NHibernateIntegration
         uses: drusellers/publish-nuget@master
         with:
@@ -629,7 +629,7 @@ jobs:
           version: ${{ needs.calc-version.outputs.version }}
           tag-commit: false
           nuget-key: ${{secrets.NUGET_API_KEY}}
-          nuget-source: https://nuget.pkg.github.com/BESTSELLER/index.json
+          nuget-source: https://nuget.pkg.github.com/BESTSELLER
       - name: Build and Publish MassTransit.RedisIntegration
         uses: drusellers/publish-nuget@master
         with:
@@ -637,7 +637,7 @@ jobs:
           version: ${{ needs.calc-version.outputs.version }}
           tag-commit: false
           nuget-key: ${{secrets.NUGET_API_KEY}}
-          nuget-source: https://nuget.pkg.github.com/BESTSELLER/index.json
+          nuget-source: https://nuget.pkg.github.com/BESTSELLER
       - name: Build and Publish MassTransit.HangfireIntegration
         uses: drusellers/publish-nuget@master
         with:
@@ -645,7 +645,7 @@ jobs:
           version: ${{ needs.calc-version.outputs.version }}
           tag-commit: false
           nuget-key: ${{secrets.NUGET_API_KEY}}
-          nuget-source: https://nuget.pkg.github.com/BESTSELLER/index.json
+          nuget-source: https://nuget.pkg.github.com/BESTSELLER
       - name: Build and Publish MassTransit.QuartzIntegration
         uses: drusellers/publish-nuget@master
         with:
@@ -653,7 +653,7 @@ jobs:
           version: ${{ needs.calc-version.outputs.version }}
           tag-commit: false
           nuget-key: ${{secrets.NUGET_API_KEY}}
-          nuget-source: https://nuget.pkg.github.com/BESTSELLER/index.json
+          nuget-source: https://nuget.pkg.github.com/BESTSELLER
       - name: Build and Publish MassTransit.ActiveMqTransport
         uses: drusellers/publish-nuget@master
         with:
@@ -661,7 +661,7 @@ jobs:
           version: ${{ needs.calc-version.outputs.version }}
           tag-commit: false
           nuget-key: ${{secrets.NUGET_API_KEY}}
-          nuget-source: https://nuget.pkg.github.com/BESTSELLER/index.json
+          nuget-source: https://nuget.pkg.github.com/BESTSELLER
       - name: Build and Publish MassTransit.AmazonSqsTransport
         uses: drusellers/publish-nuget@master
         with:
@@ -669,7 +669,7 @@ jobs:
           version: ${{ needs.calc-version.outputs.version }}
           tag-commit: false
           nuget-key: ${{secrets.NUGET_API_KEY}}
-          nuget-source: https://nuget.pkg.github.com/BESTSELLER/index.json
+          nuget-source: https://nuget.pkg.github.com/BESTSELLER
       - name: Build and Publish MassTransit.Azure.ServiceBus.Core
         uses: drusellers/publish-nuget@master
         with:
@@ -677,7 +677,7 @@ jobs:
           version: ${{ needs.calc-version.outputs.version }}
           tag-commit: false
           nuget-key: ${{secrets.NUGET_API_KEY}}
-          nuget-source: https://nuget.pkg.github.com/BESTSELLER/index.json
+          nuget-source: https://nuget.pkg.github.com/BESTSELLER
       - name: Build and Publish MassTransit.EventHubIntegration
         uses: drusellers/publish-nuget@master
         with:
@@ -685,7 +685,7 @@ jobs:
           version: ${{ needs.calc-version.outputs.version }}
           tag-commit: false
           nuget-key: ${{secrets.NUGET_API_KEY}}
-          nuget-source: https://nuget.pkg.github.com/BESTSELLER/index.json
+          nuget-source: https://nuget.pkg.github.com/BESTSELLER
       - name: Build and Publish MassTransit.Grpc
         uses: drusellers/publish-nuget@master
         with:
@@ -693,7 +693,7 @@ jobs:
           version: ${{ needs.calc-version.outputs.version }}
           tag-commit: false
           nuget-key: ${{secrets.NUGET_API_KEY}}
-          nuget-source: https://nuget.pkg.github.com/BESTSELLER/index.json
+          nuget-source: https://nuget.pkg.github.com/BESTSELLER
       - name: Build and Publish MassTransit.KafkaIntegration
         uses: drusellers/publish-nuget@master
         with:
@@ -701,7 +701,7 @@ jobs:
           version: ${{ needs.calc-version.outputs.version }}
           tag-commit: false
           nuget-key: ${{secrets.NUGET_API_KEY}}
-          nuget-source: https://nuget.pkg.github.com/BESTSELLER/index.json
+          nuget-source: https://nuget.pkg.github.com/BESTSELLER
       - name: Build and Publish MassTransit.RabbitMqTransport
         uses: drusellers/publish-nuget@master
         with:
@@ -709,7 +709,7 @@ jobs:
           version: ${{ needs.calc-version.outputs.version }}
           tag-commit: false
           nuget-key: ${{secrets.NUGET_API_KEY}}
-          nuget-source: https://nuget.pkg.github.com/BESTSELLER/index.json
+          nuget-source: https://nuget.pkg.github.com/BESTSELLER
       - name: Build and Publish MassTransit.Visualizer
         uses: drusellers/publish-nuget@master
         with:
@@ -717,7 +717,7 @@ jobs:
           version: ${{ needs.calc-version.outputs.version }}
           tag-commit: false
           nuget-key: ${{secrets.NUGET_API_KEY}}
-          nuget-source: https://nuget.pkg.github.com/BESTSELLER/index.json
+          nuget-source: https://nuget.pkg.github.com/BESTSELLER
       - name: Build and Publish MassTransit.WebJobs.EventHubsIntegration
         uses: drusellers/publish-nuget@master
         with:
@@ -725,7 +725,7 @@ jobs:
           version: ${{ needs.calc-version.outputs.version }}
           tag-commit: false
           nuget-key: ${{secrets.NUGET_API_KEY}}
-          nuget-source: https://nuget.pkg.github.com/BESTSELLER/index.json
+          nuget-source: https://nuget.pkg.github.com/BESTSELLER
       - name: Build and Publish MassTransit.WebJobs.ServiceBusIntegration
         uses: drusellers/publish-nuget@master
         with:
@@ -733,5 +733,5 @@ jobs:
           version: ${{ needs.calc-version.outputs.version }}
           tag-commit: false
           nuget-key: ${{secrets.NUGET_API_KEY}}
-          nuget-source: https://nuget.pkg.github.com/BESTSELLER/index.json
+          nuget-source: https://nuget.pkg.github.com/BESTSELLER
 

--- a/.github/workflows/sync-fork.yml
+++ b/.github/workflows/sync-fork.yml
@@ -2,7 +2,7 @@ name: Sync Fork
 
 on:
   schedule:
-    - cron: '*/30 * * * *' # every 30 minutes
+    - cron: '0 */6 * * *' # every 6 hours
   workflow_dispatch: # on button click
 
 jobs:


### PR DESCRIPTION
[No story]

Seems like the nuget source URL was resolving to `https://nuget.pkg.github.com/BESTSELLER/index.json/v3/index.json` for some reason. Hope removing the `index.json` will make it valid..